### PR TITLE
Feat/multiplayer improvements

### DIFF
--- a/backend/sockets/roomHandlers.js
+++ b/backend/sockets/roomHandlers.js
@@ -1,6 +1,10 @@
 const Room = require('../models/Room');
 const User = require('../models/Users');
 const { generateGameQuestions } = require('../utils/gameUtils');
+const redis = require('../utils/redisClient');
+const { normalize, titleArtistMatch } = require('../utils/scoringUtils');
+const Snippet = require('../models/Snippet');
+
 
 function ensureHost(room, userId) {
   if (!room?.host || room.host.toString() !== userId) {
@@ -11,6 +15,52 @@ function ensureHost(room, userId) {
 }
 
 function multiplayerRoomHandler(io, socket, socketState) {
+  const memQuestions = multiplayerRoomHandler.__q ||= new Map(); // code -> gameData
+  const memAttempts = multiplayerRoomHandler.__a ||= new Map(); // `${code}|${round}|${user}` -> count
+  const memScores = multiplayerRoomHandler.__s ||= new Map(); // code -> { [userId]: {...} }
+  const memEnded = (multiplayerRoomHandler.__ended ||= new Set());
+
+
+  const attemptKey = (code, roundIndex, userId) => `${code}|${roundIndex}|${userId}`;
+
+  async function loadScores(roomCode) {
+    // try redis first (only if enabled)
+    if (redis.enabled) {
+      try {
+        const raw = await redis.get(`room:${roomCode}:scores`);
+        if (raw) return JSON.parse(raw);
+      } catch { }
+    }
+    // fallback to memory
+    return memScores.get(roomCode) || {};
+  }
+
+  async function saveScores(roomCode, map) {
+    // always update memory
+    memScores.set(roomCode, map);
+    // also write to redis when available
+    if (redis.enabled) {
+      try {
+        await redis.set(`room:${roomCode}:scores`, JSON.stringify(map), 'EX', 3600);
+      } catch { }
+    }
+  }
+
+  async function resolveUsername(uid) {
+    try {
+      const u = await User.findById(uid).select('_id username').lean();
+      return u?.username || 'Player';
+    } catch {
+      return 'Player';
+    }
+  }
+
+  const clearRoomMem = (code) => {
+    memQuestions.delete(code);
+    memScores.delete(code);
+    for (const k of memAttempts.keys()) if (k.startsWith(`${code}|`)) memAttempts.delete(k);
+    memEnded.delete(code);
+  };
   socket.on('createRoom', async (payload, cb) => {
     try {
       const { hostId, hostSocketId, mode, settings } = payload || {};
@@ -159,41 +209,59 @@ function multiplayerRoomHandler(io, socket, socketState) {
     }
   });
 
-  // Client → startGame (host only)
   socket.on('startGame', async (payload, cb) => {
     try {
-      const { code, hostId, players } = payload || {};
-      if (!code || !hostId || !players) throw new Error('Missing code/hostId/players');
+      const { code, hostId } = payload || {};
+      if (!code || !hostId) throw new Error('Missing code/hostId');
 
       const room = await Room.findOne({ code: code.toUpperCase() });
       if (!room) throw new Error('Room not found');
       ensureHost(room, hostId);
 
       if (room.status !== 'lobby') throw new Error('Game already started or ended');
+
       room.status = 'in-game';
       room.currentRound = 1;
       await room.save();
 
-      const gameData = await generateGameQuestions(10); // or pull rounds from settings
-      await redis.set(`room:${room.code}:questions`, JSON.stringify(gameData), 'EX', 3600); // TTL 1h
+      memEnded.delete(room.code);
 
-      await redis.set(
-        `room:${room.code}:scores`,
-        JSON.stringify(
-          players.reduce((acc, player) => {
-            acc[player.id] = {
-              score: 0,
-              correct: 0,
-              finished: false,
-            };
-            return acc;
-          }, {})
-        )
-      );
+      const gameData = await generateGameQuestions(10);
+      const questionsKey = `room:${room.code}:questions`;
+      const scoresKey = `room:${room.code}:scores`;
+      const payloadStr = JSON.stringify(gameData);
+
+      try { await redis.set(questionsKey, payloadStr, 'EX', 3600); } catch { }
+      memQuestions.set(room.code, gameData);
+
+      const players = room.players || [];
+      const initialScores = {};
+      for (const p of players) {
+        const pid = (p.user || p).toString?.() || p.id || p._id || p;
+        if (!pid) continue;
+        initialScores[pid] = {
+          score: 0,
+          correct: 0,
+          finished: false,
+          streak: 0,
+          name: p.username || p.name || (await resolveUsername(pid)),
+        };
+      }
+      // include host too (some models don’t duplicate host in players array)
+      const hostPid = (room.host || '').toString?.() || room.host;
+      if (hostPid && !initialScores[hostPid]) {
+        initialScores[hostPid] = { score: 0, correct: 0, finished: false, streak: 0, name: await resolveUsername(hostPid), };
+      }
+
+      try { await redis.set(scoresKey, JSON.stringify(initialScores), 'EX', 3600); } catch { }
+      memScores.set(room.code, initialScores); // ← in-memory fallback
+
       const summary = await room.toLobbySummary();
-
       io.to(room.code).emit('room:update', summary);
-      io.to(room.code).emit('game:start', await redis.get(`room:${room.code}:questions`));
+
+      let cached = null;
+      try { cached = await redis.get(questionsKey); } catch { }
+      io.to(room.code).emit('game:start', cached ?? payloadStr);
 
       cb?.({ ok: true, room: summary });
     } catch (err) {
@@ -203,47 +271,99 @@ function multiplayerRoomHandler(io, socket, socketState) {
     }
   });
 
-  // Client → endGame (host only)
+
+
   socket.on('endGame', async (payload, cb) => {
     try {
       const { roomCode, userId } = payload || {};
       if (!roomCode || !userId) throw new Error('Missing code/userId');
 
-      scoresString = await redis.get(`room:${roomCode}:scores`);
-      const scoresJSON = JSON.parse(scoresString);
+      const room = await Room.findOne({ code: roomCode.toUpperCase() });
+      if (!room) throw new Error('Room not found');
+      ensureHost(room, userId); // host-only
 
-      const players = Object.values(scoresJSON);
-      const finishedCount = players.filter(p => p.finished).length;
-      const shouldEndGame = finishedCount >= players.length - 1;
+      room.status = 'ended';
+      await room.save();
 
-      if (shouldEndGame) {
-        const leaderboard = [];
-        for (const userId in scoresJSON) {
-          const user = await User.findById(userId);
-          const entry = {
-            name: user.username,
-            score: scoresJSON[userId].score,
-          };
-          leaderboard.push(entry);
-        }
-        leaderboard.sort((a, b) => b.score - a.score);
-        io.to(roomCode).emit('game:end', leaderboard);
-        cb?.({ allDone: true });
-      } else {
-        scoresJSON[userId].finished = true;
-        await redis.set(`room:${roomCode}:scores`, JSON.stringify(scoresJSON));
-        cb?.({ allDone: false });
+      // Get scores (prefer Redis; fall back to memory)
+      let scores = {};
+      try {
+        const scoreRaw = await redis.get(`room:${roomCode}:scores`);
+        scores = scoreRaw ? JSON.parse(scoreRaw) : (memScores.get(roomCode) || {});
+      } catch {
+        scores = memScores.get(roomCode) || {};
       }
+
+      // Build a reliable name map:
+      // 1) prefer name already stored on score entry
+      const idToName = {};
+      for (const uid of Object.keys(scores)) {
+        if (scores[uid]?.name) idToName[uid] = scores[uid].name;
+      }
+
+      // 2) fall back to room.players snapshot
+      if (room?.players?.length) {
+        for (const p of room.players) {
+          const pid = (p.user || p).toString?.() || p.id || p._id || p;
+          if (pid && !idToName[pid]) {
+            idToName[pid] = p.username || p.name;
+          }
+        }
+      }
+
+      // 3) backfill missing via DB
+      const missingIds = Object.keys(scores).filter(uid => !idToName[uid]);
+      if (missingIds.length) {
+        try {
+          const users = await User.find({ _id: { $in: missingIds } })
+            .select('_id username')
+            .lean();
+          for (const u of users || []) {
+            idToName[u._id.toString()] = u.username || 'Player';
+          }
+        } catch {
+          // ignore; anything left will default to 'Player'
+        }
+      }
+
+      // Assemble leaderboard
+      let leaderboard = [];
+      for (const uid of Object.keys(scores)) {
+        leaderboard.push({
+          userId: uid,
+          name: idToName[uid] || 'Player',
+          score: scores[uid]?.score || 0,
+        });
+      }
+      leaderboard.sort((a, b) => b.score - a.score);
+
+      // Emit once to the whole room
+      io.to(roomCode).emit('game:end', { roomCode, leaderboard });
+
+      // Cleanup
+      try {
+        await redis.del(`room:${roomCode}:questions`);
+        await redis.del(`room:${roomCode}:scores`);
+      } catch { }
+      memQuestions.delete(roomCode);
+      for (const k of memAttempts.keys()) if (k.startsWith(`${roomCode}|`)) memAttempts.delete(k);
+      // keep memScores until next game or clear if you prefer:
+      memScores.delete(roomCode);
+
+      // Lobby refresh
+      const summary = await room.toLobbySummary();
+      io.to(roomCode).emit('room:update', summary);
+
+      cb?.({ ok: true, ended: true });
     } catch (err) {
       console.error('endGame error:', err.message);
       cb?.({ ok: false, error: err.message });
-      socket.emit('room:error', err.message);
+      socket.emit('game:error', err.message);
     }
   });
 
-  const redis = require('../utils/redisClient');
-  const { normalize, titleArtistMatch } = require('../utils/scoringUtils'); // we'll extract this
-  const Snippet = require('../models/Snippet');
+
+
 
   socket.on('game:answer', async (payload, cb) => {
     try {
@@ -251,59 +371,182 @@ function multiplayerRoomHandler(io, socket, socketState) {
       if (!code || !userId || !guess) throw new Error('Missing code/userId/guess');
 
       const roomCode = code.toUpperCase();
-      const questionsRaw = await redis.get(`room:${roomCode}:questions`);
-      if (!questionsRaw) throw new Error('No questions found for this room');
 
-      const questions = JSON.parse(questionsRaw);
+      // Load questions (Redis → memory fallback)
+      const questionsRaw = await redis.get(`room:${roomCode}:questions`);
+      const questions = questionsRaw ? JSON.parse(questionsRaw) : (memQuestions.get(roomCode) || null);
+      if (!questions) throw new Error('No questions found for this room');
+
       const snippetMeta = questions.snippets[roundIndex];
       if (!snippetMeta) throw new Error('Invalid round index');
 
       const snippet = await Snippet.findById(snippetMeta.snippetId);
       if (!snippet) throw new Error('Snippet not found');
-      // Match logic (reuse from gsController)
-      const { titleHit, artistHit, correct } = titleArtistMatch(
-        guess,
-        snippet.title || '',
-        snippet.artist || ''
+
+      // Attempts (max 5)
+      const MAX_ATTEMPTS = 5;
+      const key = (multiplayerRoomHandler.__aKey || ((c, r, u) => `${c}|${r}|${u}`))(
+        roomCode,
+        roundIndex,
+        userId
       );
-      let base = 0,
-        timeBonus = 0,
-        total = 0;
-      let concluded = false;
-
-      if (correct) {
-        base = 1000;
-        timeBonus = Math.max(0, Math.round((snippetSize * 1000 - elapsedMs) / 20));
-        total = base + timeBonus;
-        concluded = true;
+      const usedSoFar = memAttempts.get(key) ?? 0;
+      if (usedSoFar >= MAX_ATTEMPTS) {
+        cb?.({ ok: false, error: 'No attempts left', attemptsLeft: 0, forceAdvance: true });
+        return;
       }
+      const newUsed = usedSoFar + 1;
+      memAttempts.set(key, newUsed);
+      const attemptsLeft = Math.max(0, MAX_ATTEMPTS - newUsed);
 
-      // Update score in Redis
+      // Match & SP-mirrored scoring
+      const { correct } = titleArtistMatch(guess, snippet.title || '', snippet.artist || '');
+
+      const snippetMs = (Number(snippetSize) || 5) * 1000;
+      const timeMs = Math.max(0, Math.round(elapsedMs - snippetMs));
+
+      const base = correct ? 1000 : 0;
+      const timeBonus = correct ? Math.max(0, Math.round((snippetMs - timeMs) / 20)) : 0;
+      const delta = correct ? base + timeBonus : 0;
+
+      // Scores map (Redis + memory fallback)
       const scoreKey = `room:${roomCode}:scores`;
       const scoreRaw = await redis.get(scoreKey);
-      const scoreMap = scoreRaw ? JSON.parse(scoreRaw) : {};
+      const scoreMap = scoreRaw ? JSON.parse(scoreRaw) : (memScores.get(roomCode) || {});
 
-      const prev = scoreMap[userId] || { score: 0, correct: 0 };
-      if (correct) {
-        prev.score += total;
-        prev.correct += 1;
+      // Ensure entry + name
+      let entry = scoreMap[userId] || { score: 0, correct: 0, finished: false, streak: 0, name: undefined };
+      if (!entry.name) {
+        // Prefer room snapshot
+        let nameFromRoom;
+        try {
+          const room = await Room.findOne({ code: roomCode }).lean();
+          if (room?.players?.length) {
+            for (const p of room.players) {
+              const pid = (p.user || p).toString?.() || p.id || p._id || p;
+              if (pid && String(pid) === String(userId)) {
+                nameFromRoom = p.username || p.name;
+                break;
+              }
+            }
+          }
+        } catch { }
+        entry.name = nameFromRoom || (await resolveUsername(userId)) || 'Player';
       }
 
-      scoreMap[userId] = prev;
-      await redis.set(scoreKey, JSON.stringify(scoreMap), 'EX', 3600);
+      // Round conclusion + streak
+      const concluded = correct || attemptsLeft === 0;
+      let newStreak = entry.streak || 0;
+      if (correct) newStreak += 1;
+      else if (concluded) newStreak = 0;
 
-      // Emit score update
+      const newScore = (entry.score || 0) + delta;
+      const newCorrect = (entry.correct || 0) + (correct ? 1 : 0);
+
+      // Mark finished if this was their last round and the round concluded
+      const isLastRoundForPlayer = roundIndex >= (questions.snippets.length - 1);
+      const finishedNow = concluded && isLastRoundForPlayer;
+
+      scoreMap[userId] = {
+        ...entry,
+        score: newScore,
+        correct: newCorrect,
+        streak: newStreak,
+        finished: finishedNow ? true : !!entry.finished,
+      };
+
+      try { await redis.set(scoreKey, JSON.stringify(scoreMap), 'EX', 3600); } catch { }
+      memScores.set(roomCode, scoreMap); // keep memory in sync
+
+      // Live updates (per guess)
       io.to(roomCode).emit('game:scoreUpdate', {
         userId,
-        newScore: prev.score,
-        correctCount: prev.correct,
+        roundIndex,
+        correct,
+        score: newScore,
+        streak: newStreak,
+        breakdown: { base, timeBonus, total: delta },
       });
 
+      // Per-round result (so clients can build song results)
+      io.to(roomCode).emit('game:roundResult', {
+        userId,
+        roundIndex,
+        correct,
+        timeMs,
+        snippetId: snippet.id,
+        title: snippet.title || 'Unknown Song',
+        artist: snippet.artist || 'Unknown Artist',
+      });
+
+      // ---- AUTO END: if everyone in the score map is finished, end the game ----
+      if (!memEnded.has(roomCode)) {
+        const participants = Object.keys(scoreMap);
+        const allFinished = participants.length > 0 && participants.every(uid => scoreMap[uid]?.finished === true);
+
+        if (allFinished) {
+          memEnded.add(roomCode);
+
+          // Build leaderboard (reuse the same logic as host-end)
+          const idToName = {};
+          for (const uid of participants) {
+            if (scoreMap[uid]?.name) idToName[uid] = scoreMap[uid].name;
+          }
+          try {
+            const room = await Room.findOne({ code: roomCode }).lean();
+            if (room?.players?.length) {
+              for (const p of room.players) {
+                const pid = (p.user || p).toString?.() || p.id || p._id || p;
+                if (pid && !idToName[pid]) idToName[pid] = p.username || p.name;
+              }
+            }
+          } catch { }
+          const missing = participants.filter(uid => !idToName[uid]);
+          if (missing.length) {
+            try {
+              const users = await User.find({ _id: { $in: missing } })
+                .select('_id username')
+                .lean();
+              for (const u of users || []) idToName[u._id.toString()] = u.username || 'Player';
+            } catch { }
+          }
+          let leaderboard = participants.map(uid => ({
+            userId: uid,
+            name: idToName[uid] || 'Player',
+            score: scoreMap[uid]?.score || 0,
+          }));
+          leaderboard.sort((a, b) => b.score - a.score);
+
+          io.to(roomCode).emit('game:end', { roomCode, leaderboard });
+
+          // cleanup
+          try {
+            await redis.del(`room:${roomCode}:questions`);
+            await redis.del(`room:${roomCode}:scores`);
+          } catch { }
+          clearRoomMem(roomCode);
+
+          // Optional: update lobby summary
+          try {
+            const room = await Room.findOne({ code: roomCode.toUpperCase() });
+            if (room) {
+              room.status = 'ended';
+              await room.save();
+              const summary = await room.toLobbySummary();
+              io.to(roomCode).emit('room:update', summary);
+            }
+          } catch { }
+        }
+      }
+
       cb?.({
+        ok: true,
         correct,
         concluded,
-        breakdown: { base, timeBonus, total },
-        score: prev.score,
+        breakdown: { base, timeBonus, total: delta },
+        score: newScore,
+        attemptsLeft,
+        forceAdvance: attemptsLeft === 0,
       });
     } catch (err) {
       console.error('game:answer error:', err.message);
@@ -312,7 +555,9 @@ function multiplayerRoomHandler(io, socket, socketState) {
     }
   });
 
-  // Guess relay (unchanged idea, scoped by { code, guess })
+
+
+
   socket.on('guess', payload => {
     try {
       const { code, guess } = payload || {};

--- a/backend/utils/gameUtils.js
+++ b/backend/utils/gameUtils.js
@@ -20,7 +20,8 @@ async function generateGameQuestions(rounds = 10) {
   const docs = await Snippet.aggregate([
     { $match: match },
     { $sample: { size: take } },
-    { $project: { _id: 1, audioUrl: 1, title: 1, artist: 1 } },
+    // include snippetSize so difficultyFromSize has consistent input
+    { $project: { _id: 1, audioUrl: 1, title: 1, artist: 1, snippetSize: 1 } },
   ]).exec();
 
   return {

--- a/frontend/src/components/GameSteps/MultiplayerGameHandler.tsx
+++ b/frontend/src/components/GameSteps/MultiplayerGameHandler.tsx
@@ -57,7 +57,6 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
   const userId = user?.id;
   const { disconnect } = useSocketStore();
 
-
   const [multiSongResults, setMultiSongResults] = useState<
     Array<{ snippetId: string; songTitle: string; artistName: string; correct: boolean }>
   >([]);
@@ -256,22 +255,22 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
   // IMPORTANT: don't navigate/disconnect here; wait for `game:end` so
   // everyone (including host) gets the leaderboard payload.
   const handleQuitGame = () => {
-  // persist local results for EndScreen
-  useGameStore.setState({ songResults: multiSongResults });
+    // persist local results for EndScreen
+    useGameStore.setState({ songResults: multiSongResults });
 
-  if (socket && roomCode && userId) {
-    socket.emit('leaveRoom', { roomId: roomCode, userId });          // non-host: just leave
-    socket.emit('endGame', { roomCode, userId }, () => {});           // host: ends for all; non-host: ignored
-  }
+    if (socket && roomCode && userId) {
+      socket.emit('leaveRoom', { roomId: roomCode, userId }); // non-host: just leave
+      socket.emit('endGame', { roomCode, userId }, () => {}); // host: ends for all; non-host: ignored
+    }
 
-  disconnect();
-  navigate('/endscreen', {
-    state: {
-      roomCode,
-      leaderboard: useGameStore.getState().leaderboard || [],
-    },
-  });
-};
+    disconnect();
+    navigate('/endscreen', {
+      state: {
+        roomCode,
+        leaderboard: useGameStore.getState().leaderboard || [],
+      },
+    });
+  };
 
   // Socket listeners
   useEffect(() => {
@@ -279,9 +278,7 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
 
     // Server emits { roomCode, leaderboard } when host ends.
     const onEnd = (payload: any) => {
-      const leaderboard: Placing[] = Array.isArray(payload)
-        ? payload
-        : payload?.leaderboard || [];
+      const leaderboard: Placing[] = Array.isArray(payload) ? payload : payload?.leaderboard || [];
 
       // ✅ ensure everyone's Song Results make it to EndScreen (non-host too)
       useGameStore.setState({ songResults: multiSongResults });
@@ -374,10 +371,13 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
     setIsPlaying(true);
     setGuessStartTime(Date.now());
     setPlaybackCount(c => c + 1);
-    timerRef.current = window.setTimeout(() => {
-      audioRef.current?.stop();
-      setIsPlaying(false);
-    }, (snippetSize || 0) * 1000);
+    timerRef.current = window.setTimeout(
+      () => {
+        audioRef.current?.stop();
+        setIsPlaying(false);
+      },
+      (snippetSize || 0) * 1000
+    );
   };
 
   const onDiscClick = () => {
@@ -486,8 +486,10 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
             <div
               className="h-full rounded-full"
               style={{
-                width: `${((currentRound + (lastResult?.concluded ? 1 : 0)) / multiplayerQuestions.length) * 100
-                  }%`,
+                width: `${
+                  ((currentRound + (lastResult?.concluded ? 1 : 0)) / multiplayerQuestions.length) *
+                  100
+                }%`,
                 background: 'linear-gradient(90deg, #0FC1E9 0%, #3B82F6 100%)',
                 transition: 'width 0.5s ease-in-out',
               }}
@@ -599,7 +601,9 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
                     lastResult?.concluded ? 'Round concluded' : ' Enter your answer here'
                   }
                   className="flex-1 p-5 text-base sm:text-lg bg-transparent text-white placeholder-gray-300 text-center focus:outline-none transition-all duration-300 focus:placeholder-transparent disabled:opacity-60"
-                  disabled={lastResult?.concluded || (attemptsLeft !== undefined && attemptsLeft <= 0)}
+                  disabled={
+                    lastResult?.concluded || (attemptsLeft !== undefined && attemptsLeft <= 0)
+                  }
                   autoFocus
                 />
                 <motion.button
@@ -609,12 +613,13 @@ const MultiplayerGameHandler: React.FC<Props> = ({ user }) => {
                     !guess.trim() ||
                     (attemptsLeft !== undefined && attemptsLeft <= 0)
                   }
-                  className={`px-8 font-bold py-5 text-base transition-all duration-300 whitespace-nowrap relative overflow-hidden ${lastResult?.concluded ||
-                      !guess.trim() ||
-                      (attemptsLeft !== undefined && attemptsLeft <= 0)
+                  className={`px-8 font-bold py-5 text-base transition-all duration-300 whitespace-nowrap relative overflow-hidden ${
+                    lastResult?.concluded ||
+                    !guess.trim() ||
+                    (attemptsLeft !== undefined && attemptsLeft <= 0)
                       ? 'bg-gray-700/50 cursor-not-allowed text-gray-500'
                       : 'bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-400 hover:to-blue-500 text-white shadow-lg hover:shadow-cyan-500/25'
-                    }`}
+                  }`}
                   whileHover={
                     !(
                       lastResult?.concluded ||

--- a/frontend/src/components/SharedProgressBar.tsx
+++ b/frontend/src/components/SharedProgressBar.tsx
@@ -8,7 +8,7 @@ export type MultiProgress = {
       username: string;
       score: number;
       correctCount: number;
-      currentRound: number; // 0-based
+      currentRound: number;     // 0-based
       answeredThisRound: boolean;
     }
   >;
@@ -17,8 +17,8 @@ export type MultiProgress = {
 type Props = {
   progress: MultiProgress | null | undefined;
   myUserId?: string;
-  height?: number; // progress bar height (px)
-  avatarSize?: number; // icon diameter (px)
+  height?: number;          // progress bar height (px)
+  avatarSize?: number;      // icon diameter (px)
   className?: string;
 };
 
@@ -29,8 +29,8 @@ function colorForId(seed: string) {
   let h = 0;
   for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
   const hue = h % 360;
-  const sat = 75; // %
-  const lgt = 60; // %
+  const sat = 75;  // %
+  const lgt = 60;  // %
   return `hsl(${hue} ${sat}% ${lgt}%)`;
 }
 
@@ -83,7 +83,8 @@ const SharedProgressBar: React.FC<Props> = ({
           <div className="relative h-full w-full">
             {entries.map(([uid, p]) => {
               // Percent progress through rounds; advance +1 if they’ve concluded this round
-              const rawPct = (p.currentRound + (p.answeredThisRound ? 1 : 0)) / total;
+              const rawPct =
+                (p.currentRound + (p.answeredThisRound ? 1 : 0)) / total;
 
               // left in px will be set in CSS using calc() that considers padding
               // We still clamp percentage to keep icons within padding bounds visually.
@@ -104,18 +105,18 @@ const SharedProgressBar: React.FC<Props> = ({
               const isMe = myUserId && String(uid) === String(myUserId);
 
               const bg = colorForId(uid || p.username || 'seed');
-              const ring = isMe
-                ? '0 0 0 2px rgba(255,255,255,0.95)'
-                : '0 0 0 1px rgba(255,255,255,0.55)';
-              const halo = isMe
-                ? '0 0 10px rgba(15,193,233,0.6)'
-                : '0 0 6px rgba(255,255,255,0.25)';
+              const ring = isMe ? '0 0 0 2px rgba(255,255,255,0.95)' : '0 0 0 1px rgba(255,255,255,0.55)';
+              const halo = isMe ? '0 0 10px rgba(15,193,233,0.6)' : '0 0 6px rgba(255,255,255,0.25)';
 
               // Initial letter
               const initial = (p.username?.[0] || 'P').toUpperCase();
 
               return (
-                <div key={uid} className="absolute top-1/2 -translate-y-1/2" style={leftStyle}>
+                <div
+                  key={uid}
+                  className="absolute top-1/2 -translate-y-1/2"
+                  style={leftStyle}
+                >
                   <div
                     className="flex items-center justify-center rounded-full select-none"
                     title={p.username}

--- a/frontend/src/components/SharedProgressBar.tsx
+++ b/frontend/src/components/SharedProgressBar.tsx
@@ -1,3 +1,4 @@
+// frontend/src/components/SharedProgressBar.tsx
 import React, { useMemo } from 'react';
 
 export type MultiProgress = {
@@ -8,7 +9,7 @@ export type MultiProgress = {
       username: string;
       score: number;
       correctCount: number;
-      currentRound: number;     // 0-based
+      currentRound: number;    // 0-based
       answeredThisRound: boolean;
     }
   >;
@@ -17,8 +18,8 @@ export type MultiProgress = {
 type Props = {
   progress: MultiProgress | null | undefined;
   myUserId?: string;
-  height?: number;          // progress bar height (px)
-  avatarSize?: number;      // icon diameter (px)
+  height?: number;       // progress bar height (px)
+  avatarSize?: number;   // icon diameter (px)
   className?: string;
 };
 
@@ -29,8 +30,8 @@ function colorForId(seed: string) {
   let h = 0;
   for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
   const hue = h % 360;
-  const sat = 75;  // %
-  const lgt = 60;  // %
+  const sat = 75; // %
+  const lgt = 60; // %
   return `hsl(${hue} ${sat}% ${lgt}%)`;
 }
 
@@ -58,9 +59,7 @@ const SharedProgressBar: React.FC<Props> = ({
     );
   }
 
-  const padding = Math.ceil(avatarSize / 2) + 2; // keeps icons fully inside
   const trackBg = 'rgba(255,255,255,0.12)';
-  const trackTint = 'linear-gradient(90deg, #0FC1E9 0%, #3B82F6 100%)';
 
   return (
     <div className={`w-full mb-4 ${className}`}>
@@ -69,13 +68,10 @@ const SharedProgressBar: React.FC<Props> = ({
         className="relative rounded-full overflow-hidden"
         style={{ height, backgroundColor: trackBg }}
       >
-        {/* We render a “ghost” fill just so the track looks alive; shared-progress is players’ icons */}
+        {/* Ghost fill to keep the track “alive” */}
         <div
           className="absolute inset-y-0 left-0 rounded-full"
-          style={{
-            width: '100%', // full width background for consistency
-            background: 'transparent',
-          }}
+          style={{ width: '100%', background: 'transparent' }}
         />
 
         {/* Avatars */}
@@ -83,40 +79,27 @@ const SharedProgressBar: React.FC<Props> = ({
           <div className="relative h-full w-full">
             {entries.map(([uid, p]) => {
               // Percent progress through rounds; advance +1 if they’ve concluded this round
-              const rawPct =
-                (p.currentRound + (p.answeredThisRound ? 1 : 0)) / total;
-
-              // left in px will be set in CSS using calc() that considers padding
-              // We still clamp percentage to keep icons within padding bounds visually.
+              const rawPct = (p.currentRound + (p.answeredThisRound ? 1 : 0)) / total;
               const pct = clamp(rawPct, 0, 1);
 
-              // Positioning:
-              // We use translateX(-50%) to center the avatar; to avoid clipping,
-              // we clamp the *final* pixel position by adding padding via CSS var.
-              // The container is full width; we approximate with “calc()” using %
-              // and a min/max with padding.
               const leftStyle = {
                 left: `calc(${pct * 100}% )`,
-                // We’ll clamp at runtime with transform and CSS max/min using padding zones
                 transform: 'translateX(-50%)',
               } as React.CSSProperties;
 
-              // Style differences for "me"
               const isMe = myUserId && String(uid) === String(myUserId);
-
               const bg = colorForId(uid || p.username || 'seed');
-              const ring = isMe ? '0 0 0 2px rgba(255,255,255,0.95)' : '0 0 0 1px rgba(255,255,255,0.55)';
-              const halo = isMe ? '0 0 10px rgba(15,193,233,0.6)' : '0 0 6px rgba(255,255,255,0.25)';
+              const ring = isMe
+                ? '0 0 0 2px rgba(255,255,255,0.95)'
+                : '0 0 0 1px rgba(255,255,255,0.55)';
+              const halo = isMe
+                ? '0 0 10px rgba(15,193,233,0.6)'
+                : '0 0 6px rgba(255,255,255,0.25)';
 
-              // Initial letter
               const initial = (p.username?.[0] || 'P').toUpperCase();
 
               return (
-                <div
-                  key={uid}
-                  className="absolute top-1/2 -translate-y-1/2"
-                  style={leftStyle}
-                >
+                <div key={uid} className="absolute top-1/2 -translate-y-1/2" style={leftStyle}>
                   <div
                     className="flex items-center justify-center rounded-full select-none"
                     title={p.username}
@@ -128,8 +111,6 @@ const SharedProgressBar: React.FC<Props> = ({
                       fontSize: Math.max(10, Math.floor(avatarSize * 0.55)),
                       fontWeight: 800,
                       boxShadow: `${ring}, ${halo}`,
-                      // Avoid clipping at very start/end by adding invisible hitbox padding
-                      // (This padding doesn’t affect layout since we’re absolutely positioned.)
                       paddingLeft: 0,
                     }}
                   >
@@ -141,8 +122,6 @@ const SharedProgressBar: React.FC<Props> = ({
           </div>
         </div>
       </div>
-
-      {/* (Intentionally no labels beneath icons per your request) */}
     </div>
   );
 };

--- a/frontend/src/pages/EndScreen.tsx
+++ b/frontend/src/pages/EndScreen.tsx
@@ -7,7 +7,11 @@ import { useAuth } from '../stores/auth';
 const allTabs = [
   { id: 'overview', label: 'Overview', showInModes: ['classic', 'inference', 'multiplayer'] },
   { id: 'leaderboard', label: 'Leaderboard', showInModes: ['multiplayer'] },
-  { id: 'songresults', label: 'Song Results', showInModes: ['classic', 'inference', 'multiplayer'] },
+  {
+    id: 'songresults',
+    label: 'Song Results',
+    showInModes: ['classic', 'inference', 'multiplayer'],
+  },
 ];
 
 const EndScreen = () => {
@@ -61,7 +65,16 @@ const EndScreen = () => {
     animatedCorrectAnswers.set(correctAnswers);
     animatedStreak.set(streak);
     animatedTimeBonus.set(timeBonus);
-  }, [score, correctAnswers, streak, timeBonus, animatedScore, animatedCorrectAnswers, animatedStreak, animatedTimeBonus]);
+  }, [
+    score,
+    correctAnswers,
+    streak,
+    timeBonus,
+    animatedScore,
+    animatedCorrectAnswers,
+    animatedStreak,
+    animatedTimeBonus,
+  ]);
 
   const displayScore = useTransform(animatedScore, value => Math.floor(value));
   const displayCorrectAnswers = useTransform(animatedCorrectAnswers, value => Math.floor(value));
@@ -80,7 +93,9 @@ const EndScreen = () => {
 
             <div className="flex flex-row justify-between items-center gap-4 w-full">
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
-                <motion.span className="text-xl font-bold text-center">{displayCorrectAnswers}</motion.span>
+                <motion.span className="text-xl font-bold text-center">
+                  {displayCorrectAnswers}
+                </motion.span>
                 <span className="text-sm text-center">Correct Answers</span>
               </div>
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
@@ -97,7 +112,9 @@ const EndScreen = () => {
                 <span className="text-sm text-center">Fastest Time</span>
               </div>
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
-                <motion.span className="text-xl font-bold text-center">{displayTimeBonus}</motion.span>
+                <motion.span className="text-xl font-bold text-center">
+                  {displayTimeBonus}
+                </motion.span>
                 <span className="text-sm text-center">Time Bonus</span>
               </div>
             </div>
@@ -113,12 +130,17 @@ const EndScreen = () => {
             {effectiveLeaderboard.map((player, index) => (
               <div
                 key={index + 1}
-                className={`flex justify-between items-center w-full px-4 py-3 rounded-xl ${player.name === user?.username ? 'bg-teal/20 border border-teal' : 'bg-darkestblue'
-                  }`}
+                className={`flex justify-between items-center w-full px-4 py-3 rounded-xl ${
+                  player.name === user?.username
+                    ? 'bg-teal/20 border border-teal'
+                    : 'bg-darkestblue'
+                }`}
               >
                 <div className="flex items-center gap-3">
                   <span className="text-lg font-bold w-6">{index + 1}</span>
-                  <span className={player.name === user?.username ? 'font-semibold' : ''}>{player.name}</span>
+                  <span className={player.name === user?.username ? 'font-semibold' : ''}>
+                    {player.name}
+                  </span>
                 </div>
                 <span className="font-bold">{player.score}</span>
               </div>
@@ -145,8 +167,9 @@ const EndScreen = () => {
                   </div>
                   <div className="flex items-center gap-3">
                     <span
-                      className={`w-6 h-6 rounded-full flex items-center justify-center ${song.correct ? 'bg-green-500' : 'bg-red-500'
-                        }`}
+                      className={`w-6 h-6 rounded-full flex items-center justify-center ${
+                        song.correct ? 'bg-green-500' : 'bg-red-500'
+                      }`}
                     >
                       {song.correct ? '✓' : '✗'}
                     </span>
@@ -219,8 +242,9 @@ const EndScreen = () => {
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`${activeTab === tab.id ? '' : 'hover:text-white/60'
-                    } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 whitespace-nowrap`}
+                  className={`${
+                    activeTab === tab.id ? '' : 'hover:text-white/60'
+                  } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 whitespace-nowrap`}
                   style={{ WebkitTapHighlightColor: 'transparent' }}
                 >
                   {activeTab === tab.id && (

--- a/frontend/src/pages/EndScreen.tsx
+++ b/frontend/src/pages/EndScreen.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { motion, useSpring, useTransform } from 'framer-motion';
 import { useState, useEffect } from 'react';
 import useGameStore from '../stores/GameSessionStore';
@@ -7,16 +7,15 @@ import { useAuth } from '../stores/auth';
 const allTabs = [
   { id: 'overview', label: 'Overview', showInModes: ['classic', 'inference', 'multiplayer'] },
   { id: 'leaderboard', label: 'Leaderboard', showInModes: ['multiplayer'] },
-  {
-    id: 'songresults',
-    label: 'Song Results',
-    showInModes: ['classic', 'inference', 'multiplayer'],
-  },
+  { id: 'songresults', label: 'Song Results', showInModes: ['classic', 'inference', 'multiplayer'] },
 ];
 
 const EndScreen = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user } = useAuth();
+
+  // Store-derived stats (kept as-is)
   const score = useGameStore(s => s.score);
   const correctAnswers = useGameStore(s => s.correctAnswers);
   const streak = useGameStore(s => s.streak);
@@ -28,14 +27,30 @@ const EndScreen = () => {
 
   const currentRound = useGameStore(s => s.currentRound);
   const rounds = useGameStore(s => s.rounds);
-  const leaderboard = useGameStore(s => s.leaderboard);
+  const storeLeaderboard = useGameStore(s => s.leaderboard);
+
   const isComplete = currentRound + 1 >= rounds;
+
+  // Prefer leaderboard coming from navigation payload (server-driven)
+  const navState = (location.state || {}) as {
+    roomCode?: string;
+    leaderboard?: Array<{ name: string; score: number }>;
+  };
+
+  const effectiveLeaderboard =
+    (Array.isArray(navState.leaderboard) && navState.leaderboard.length > 0
+      ? navState.leaderboard
+      : storeLeaderboard) || [];
+
+  // Ensure the Leaderboard tab appears when multiplayer data is present
+  const effectiveMode = mode || (effectiveLeaderboard.length > 0 ? 'multiplayer' : 'classic');
+
+  const tabs = allTabs.filter(tab => tab.showInModes.includes(effectiveMode));
+  const [activeTab, setActiveTab] = useState<string>(tabs[0]?.id || 'overview');
 
   const [showEarlyQuitModal, setShowEarlyQuitModal] = useState(!isComplete);
 
-  const tabs = allTabs.filter(tab => tab.showInModes.includes(mode));
-  const [activeTab, setActiveTab] = useState(tabs[0].id);
-
+  // Animated counters
   const animatedScore = useSpring(0, { duration: 2000 });
   const animatedCorrectAnswers = useSpring(0, { duration: 1000 });
   const animatedStreak = useSpring(0, { duration: 1000 });
@@ -46,7 +61,7 @@ const EndScreen = () => {
     animatedCorrectAnswers.set(correctAnswers);
     animatedStreak.set(streak);
     animatedTimeBonus.set(timeBonus);
-  }, [score, correctAnswers, streak, timeBonus]);
+  }, [score, correctAnswers, streak, timeBonus, animatedScore, animatedCorrectAnswers, animatedStreak, animatedTimeBonus]);
 
   const displayScore = useTransform(animatedScore, value => Math.floor(value));
   const displayCorrectAnswers = useTransform(animatedCorrectAnswers, value => Math.floor(value));
@@ -65,9 +80,7 @@ const EndScreen = () => {
 
             <div className="flex flex-row justify-between items-center gap-4 w-full">
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
-                <motion.span className="text-xl font-bold text-center">
-                  {displayCorrectAnswers}
-                </motion.span>
+                <motion.span className="text-xl font-bold text-center">{displayCorrectAnswers}</motion.span>
                 <span className="text-sm text-center">Correct Answers</span>
               </div>
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
@@ -84,9 +97,7 @@ const EndScreen = () => {
                 <span className="text-sm text-center">Fastest Time</span>
               </div>
               <div className="flex flex-col items-center justify-center bg-darkestblue rounded-xl px-6 py-4 w-1/2 h-20 mb-3">
-                <motion.span className="text-xl font-bold text-center">
-                  {displayTimeBonus}
-                </motion.span>
+                <motion.span className="text-xl font-bold text-center">{displayTimeBonus}</motion.span>
                 <span className="text-sm text-center">Time Bonus</span>
               </div>
             </div>
@@ -94,26 +105,20 @@ const EndScreen = () => {
         );
 
       case 'leaderboard':
-        return leaderboard.length < 1 ? (
-          <h3>Nothing to see here! </h3> //Replace with actual thing
+        return effectiveLeaderboard.length < 1 ? (
+          <h3>Nothing to see here!</h3>
         ) : (
           <div className="flex flex-col items-center w-full space-y-3">
             <h3 className="text-lg font-semibold mb-2">Top Players</h3>
-            {/* Placeholder for leaderboard data */}
-            {leaderboard.map((player, index) => (
+            {effectiveLeaderboard.map((player, index) => (
               <div
                 key={index + 1}
-                className={`flex justify-between items-center w-full px-4 py-3 rounded-xl ${
-                  player.name === user?.username
-                    ? 'bg-teal/20 border border-teal'
-                    : 'bg-darkestblue'
-                }`}
+                className={`flex justify-between items-center w-full px-4 py-3 rounded-xl ${player.name === user?.username ? 'bg-teal/20 border border-teal' : 'bg-darkestblue'
+                  }`}
               >
                 <div className="flex items-center gap-3">
                   <span className="text-lg font-bold w-6">{index + 1}</span>
-                  <span className={player.name === user?.username ? 'font-semibold' : ''}>
-                    {player.name}
-                  </span>
+                  <span className={player.name === user?.username ? 'font-semibold' : ''}>{player.name}</span>
                 </div>
                 <span className="font-bold">{player.score}</span>
               </div>
@@ -140,9 +145,8 @@ const EndScreen = () => {
                   </div>
                   <div className="flex items-center gap-3">
                     <span
-                      className={`w-6 h-6 rounded-full flex items-center justify-center ${
-                        song.correct ? 'bg-green-500' : 'bg-red-500'
-                      }`}
+                      className={`w-6 h-6 rounded-full flex items-center justify-center ${song.correct ? 'bg-green-500' : 'bg-red-500'
+                        }`}
                     >
                       {song.correct ? '✓' : '✗'}
                     </span>
@@ -159,45 +163,30 @@ const EndScreen = () => {
   };
 
   const getMessage = () => {
-    if (mode === 'multiplayer') {
-      const playerRank = leaderboard.findIndex(player => player.name === user?.username) + 1;
+    if (effectiveMode === 'multiplayer') {
+      const playerRank = effectiveLeaderboard.findIndex(p => p.name === user?.username) + 1;
 
       if (isComplete) {
-        if (playerRank === 1) {
-          return `${playerRank}st  Place!`;
-        } else if (playerRank === 2) {
-          return `${playerRank}nd Place!`;
-        } else if (playerRank === 3) {
-          return '3rd Place!';
-        } else {
-          return `${playerRank}th Place!`;
-        }
+        if (playerRank === 1) return `${playerRank}st  Place!`;
+        if (playerRank === 2) return `${playerRank}nd Place!`;
+        if (playerRank === 3) return '3rd Place!';
+        return playerRank > 0 ? `${playerRank}th Place!` : 'Great Game!';
       }
       return 'Great Game!';
     }
 
-    if (score >= 8000) {
-      return 'Outstanding!';
-    } else if (score >= 7500) {
-      return 'Excellent Work!';
-    } else if (score >= 5000) {
-      return 'Great Job!';
-    } else if (score >= 1500) {
-      return 'Good Effort!';
-    } else {
-      return 'Keep Trying!';
-    }
+    if (score >= 8000) return 'Outstanding!';
+    if (score >= 7500) return 'Excellent Work!';
+    if (score >= 5000) return 'Great Job!';
+    if (score >= 1500) return 'Good Effort!';
+    return 'Keep Trying!';
   };
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center font-montserrat p-4">
       <motion.div
         className="backdrop-blur-sm bg-darkblue/80 rounded-xl shadow-lg relative text-white overflow-hidden"
-        style={{
-          width: '100%',
-          maxWidth: '600px',
-          height: '600px',
-        }}
+        style={{ width: '100%', maxWidth: '600px', height: '600px' }}
         initial={{ opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.5, ease: 'easeOut' }}
@@ -230,12 +219,9 @@ const EndScreen = () => {
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`${
-                    activeTab === tab.id ? '' : 'hover:text-white/60'
-                  } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 whitespace-nowrap`}
-                  style={{
-                    WebkitTapHighlightColor: 'transparent',
-                  }}
+                  className={`${activeTab === tab.id ? '' : 'hover:text-white/60'
+                    } relative rounded-full px-3 py-1.5 text-sm font-medium text-white outline-sky-400 transition focus-visible:outline-2 whitespace-nowrap`}
+                  style={{ WebkitTapHighlightColor: 'transparent' }}
                 >
                   {activeTab === tab.id && (
                     <motion.span
@@ -295,17 +281,14 @@ const EndScreen = () => {
             animate={{ scale: 1, y: 0 }}
             transition={{ type: 'spring', duration: 0.5 }}
           >
-            {/* Icon */}
             <div className="flex justify-center mb-4">
               <div className="w-16 h-16 rounded-full bg-teal/20 flex items-center justify-center">
                 <span className="text-white text-4xl">☹</span>
               </div>
             </div>
 
-            {/* Title */}
             <h2 className="text-2xl font-bold text-center text-white mb-3">Game Ended Early</h2>
 
-            {/* Message */}
             <p className="text-center text-white/90 mb-2">
               You completed <span className="font-bold text-teal">{currentRound + 1}</span> of{' '}
               <span className="font-bold text-teal">{rounds}</span> rounds.
@@ -314,7 +297,6 @@ const EndScreen = () => {
               These are your stats from the rounds you completed.
             </p>
 
-            {/* Okay Button */}
             <motion.button
               onClick={() => setShowEarlyQuitModal(false)}
               className="w-full px-6 py-3 bg-teal hover:bg-teal/80 text-white rounded-xl font-bold transition-colors shadow-lg"

--- a/frontend/src/pages/GroupLobby.tsx
+++ b/frontend/src/pages/GroupLobby.tsx
@@ -104,33 +104,64 @@ const GroupLobby: React.FC = () => {
       disconnect();
     });
 
-    // room created / joined / updates
     socket.on('room:created', (summary: LobbySummary) => {
       setRoomId(summary.code);
       setLobbyPlayers(summary.players || []);
       setRoomStatus(summary.status);
     });
+
     socket.on('room:joined', (summary: LobbySummary) => {
       setRoomId(summary.code);
       setLobbyPlayers(summary.players || []);
       setRoomStatus(summary.status);
     });
+
     socket.on('room:left', () => {
       setRoomId('');
       setLobbyPlayers([]);
     });
+
     socket.on('room:update', (summary: LobbySummary) => {
-      if (summary) setRoomId(summary.code);
+      if (!summary) return; // guard against null payloads
+      setRoomId(summary.code);
       useGameStore.getState().setRoomCode(summary.code);
       setLobbyPlayers(summary.players || []);
       setRoomStatus(summary.status);
     });
-    socket.on('game:start', (questions: string) => {
-      useGameStore.getState().setMultiplayerQuestions(JSON.parse(questions).snippets);
-      setRoomStatus('in-game');
-      navigateGame();
+
+    // GroupLobby.tsx — inside your socket registrations
+    socket.on('game:start', (questions: string | { snippets?: unknown; rounds?: number }) => {
+      try {
+        const parsed = typeof questions === 'string' ? JSON.parse(questions) : questions;
+        const snippets = (parsed as any)?.snippets;
+        const rounds = (parsed as any)?.rounds ?? (Array.isArray(snippets) ? snippets.length : 0);
+        if (!Array.isArray(snippets)) {
+          console.error('game:start payload missing `snippets` array', parsed);
+          return;
+        }
+        useGameStore.getState().setMultiplayerQuestions(snippets);
+        useGameStore.getState().setConfig?.({ mode: 'multiplayer', rounds }); // <-- add this
+        setRoomStatus('in-game');
+        navigateGame();
+      } catch (e) {
+        console.error('Failed to parse game:start payload', e, questions);
+      }
     });
 
+
+
+    // GroupLobby.tsx — alongside the other socket.on(...) calls
+    socket.on('game:end', (data?: any) => {
+      setRoomStatus('ended');
+
+      const leaderboard = Array.isArray(data) ? data : data?.leaderboard || [];
+      const code = Array.isArray(data) ? roomId : (data?.roomCode || roomId);
+
+      navigate('/endscreen', { state: { roomCode: code, leaderboard } });
+    });
+
+
+    // Keep your existing cleanup:
     return () => {
       handleLeave();
     };
@@ -376,11 +407,10 @@ const GroupLobby: React.FC = () => {
                 <motion.button
                   onClick={handleStartGame}
                   disabled={lobbyPlayers.length + 1 < 2}
-                  className={`px-8 py-3 rounded-xl font-semibold ${
-                    lobbyPlayers.length + 1 >= 2
-                      ? 'bg-cyan-500 text-white shadow-lg shadow-cyan-500/25'
-                      : 'bg-gray-600/50 cursor-not-allowed text-gray-400'
-                  }`}
+                  className={`px-8 py-3 rounded-xl font-semibold ${lobbyPlayers.length + 1 >= 2
+                    ? 'bg-cyan-500 text-white shadow-lg shadow-cyan-500/25'
+                    : 'bg-gray-600/50 cursor-not-allowed text-gray-400'
+                    }`}
                   whileHover={lobbyPlayers.length + 1 >= 2 ? { scale: 1.02 } : {}}
                   whileTap={lobbyPlayers.length + 1 >= 2 ? { scale: 0.98 } : {}}
                 >

--- a/frontend/src/pages/GroupLobby.tsx
+++ b/frontend/src/pages/GroupLobby.tsx
@@ -148,18 +148,15 @@ const GroupLobby: React.FC = () => {
       }
     });
 
-
-
     // GroupLobby.tsx — alongside the other socket.on(...) calls
     socket.on('game:end', (data?: any) => {
       setRoomStatus('ended');
 
       const leaderboard = Array.isArray(data) ? data : data?.leaderboard || [];
-      const code = Array.isArray(data) ? roomId : (data?.roomCode || roomId);
+      const code = Array.isArray(data) ? roomId : data?.roomCode || roomId;
 
       navigate('/endscreen', { state: { roomCode: code, leaderboard } });
     });
-
 
     // Keep your existing cleanup:
     return () => {
@@ -407,10 +404,11 @@ const GroupLobby: React.FC = () => {
                 <motion.button
                   onClick={handleStartGame}
                   disabled={lobbyPlayers.length + 1 < 2}
-                  className={`px-8 py-3 rounded-xl font-semibold ${lobbyPlayers.length + 1 >= 2
-                    ? 'bg-cyan-500 text-white shadow-lg shadow-cyan-500/25'
-                    : 'bg-gray-600/50 cursor-not-allowed text-gray-400'
-                    }`}
+                  className={`px-8 py-3 rounded-xl font-semibold ${
+                    lobbyPlayers.length + 1 >= 2
+                      ? 'bg-cyan-500 text-white shadow-lg shadow-cyan-500/25'
+                      : 'bg-gray-600/50 cursor-not-allowed text-gray-400'
+                  }`}
                   whileHover={lobbyPlayers.length + 1 >= 2 ? { scale: 1.02 } : {}}
                   whileTap={lobbyPlayers.length + 1 >= 2 ? { scale: 0.98 } : {}}
                 >


### PR DESCRIPTION
This PR makes multiplayer fully functional with and without Redis, fixes score resets, wires up proper endgame flows (host and non-host), and ensures leaderboards and per-round song results render correctly for all players.

NOTE: Leaderboard does not currently display correctly for the host after doing a host-quit (this applies only for the non-Redis mp).

Key changes
Backend

No-Redis fallback: All multiplayer state (questions, attempts, scores) now has an in-memory fallback (memQuestions, memAttempts, memScores). Works when REDIS_DISABLE=1 or Redis is unreachable.

Authoritative scoring: game: answer updates a per-room scores map and emits game:scoreUpdate + game:roundResult.

Endgame events:

Host end: endGame emits a single game: end with a sorted leaderboard and cleans up room state.

Auto end: when all participants are finished, the server emits game: end automatically.

Non-host quit: player can leave without ending the room; they’re routed to EndScreen locally.

Reliable usernames: Leaderboard name resolution uses (1) score entry name, (2) room.players, (3) DB backfill (Users.username) to avoid “Player” fallbacks.

Cleanup: consistent room memory cleanup; Redis keys deleted when the game ends.

Frontend

MultiplayerGameHandler

Trusts server for score/streak via game:scoreUpdate.

Builds per-round Song Results from game:roundResult.

Handles host end, auto end, and non-host quit → navigates to EndScreen with leaderboard + results preserved.

EndScreen

Shows Leaderboard (server payload) and Song Results (client-built).

Early-quit banner for incomplete games.

SharedProgressBar

Clean, minimal shared progress avatars; deterministic colors; safe positioning (still needs to be wired into the mp GameScreen)


Notes / Risks

In-memory fallback is per server process (not shared across multiple instances).